### PR TITLE
Add pipeline name to getpipelinevars and getpipelinesecrets AND add new module downloadbuildlogs

### DIFF
--- a/ADOKit/ADOKit.cs
+++ b/ADOKit/ADOKit.cs
@@ -19,8 +19,9 @@ namespace ADOKit
         private static string search = "";
         private static string id = "";
         private static string sshKey = "";
-        private static List<string> approvedModules = new List<string> { "check", "whoami", "listrepo", "searchrepo", "listproject", "searchproject", "searchcode", "searchfile", "listuser", "searchuser", "listgroup", "searchgroup", "getgroupmembers", "getpermissions", "createpat", "removepat", "listpat", "createsshkey", "removesshkey", "listsshkey", "addprojectadmin", "removeprojectadmin", "addbuildadmin", "removebuildadmin", "addcollectionadmin", "removecollectionadmin", "addcollectionbuildadmin", "removecollectionbuildadmin", "addcollectionbuildsvc", "removecollectionbuildsvc", "addcollectionsvc", "removecollectionsvc", "getpipelinevars", "getpipelinesecrets", "getvariablegroups", "getserviceconnections" };
-
+        private static string outfolder = "."; // default to local folder
+        private static bool reallyDownload = false; // default just avoiding to download all the things if you don't really want it
+        private static List<string> approvedModules = new List<string> { "check", "whoami", "listrepo", "searchrepo", "listproject", "searchproject", "searchcode", "searchfile", "listuser", "searchuser", "listgroup", "searchgroup", "getgroupmembers", "getpermissions", "downloadbuildlogs", "createpat", "removepat", "listpat", "createsshkey", "removesshkey", "listsshkey", "addprojectadmin", "removeprojectadmin", "addbuildadmin", "removebuildadmin", "addcollectionadmin", "removecollectionadmin", "addcollectionbuildadmin", "removecollectionbuildadmin", "addcollectionbuildsvc", "removecollectionbuildsvc", "addcollectionsvc", "removecollectionsvc", "getpipelinevars", "getpipelinesecrets", "getvariablegroups", "getserviceconnections" };
 
 
         static async Task Main(string[] args)
@@ -123,6 +124,22 @@ namespace ADOKit
 
                 }
 
+                // Output folder
+                if (argDict.ContainsKey("outfolder"))
+                {
+
+                    outfolder = argDict["outfolder"];
+
+                }
+
+                // Really download all the build logs? I assume you know what you're doing
+                if (argDict.ContainsKey("reallydownload"))
+                {
+
+                    reallyDownload = true;
+
+                }
+
                 // determine if invalid module was given
                 if (!approvedModules.Contains(module))
                 {
@@ -176,6 +193,9 @@ namespace ADOKit
                         break;
                     case "getpermissions":
                         await Modules.Recon.GetPermissions.execute(credential, url, project);
+                        break;
+                    case "downloadbuildlogs":
+                        await Modules.Recon.DownloadBuildLogs.execute(credential, url, project, outfolder, reallyDownload);
                         break;
                     case "createpat":
                         await Modules.Persistence.CreatePAT.execute(credential, url);

--- a/ADOKit/ADOKit.csproj
+++ b/ADOKit/ADOKit.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Modules\Recon\GetGroupMembers.cs" />
     <Compile Include="Modules\Recon\GetPermissions.cs" />
     <Compile Include="Modules\Recon\ListGroup.cs" />
+    <Compile Include="Modules\Recon\DownloadBuildLogs.cs" />
     <Compile Include="Modules\Recon\ListProject.cs" />
     <Compile Include="Modules\Recon\ListRepo.cs" />
     <Compile Include="Modules\Recon\ListUser.cs" />
@@ -88,6 +89,8 @@
     <Compile Include="Modules\Recon\SearchRepo.cs" />
     <Compile Include="Modules\Recon\SearchUser.cs" />
     <Compile Include="Modules\Recon\Whoami.cs" />
+    <Compile Include="Objects\BuildLog.cs" />
+    <Compile Include="Objects\Build.cs" />
     <Compile Include="Objects\GroupVariable.cs" />
     <Compile Include="Objects\BuildVariable.cs" />
     <Compile Include="Objects\CodeResult.cs" />
@@ -107,6 +110,7 @@
     <Compile Include="Utilities\FileUtils.cs" />
     <Compile Include="Utilities\GroupUtils.cs" />
     <Compile Include="Utilities\PatUtils.cs" />
+    <Compile Include="Utilities\BuildUtils.cs" />
     <Compile Include="Utilities\PipelineUtils.cs" />
     <Compile Include="Utilities\ProjectUtils.cs" />
     <Compile Include="Utilities\RepoUtils.cs" />

--- a/ADOKit/ADOKit.csproj
+++ b/ADOKit/ADOKit.csproj
@@ -65,9 +65,9 @@
     <Compile Include="Modules\Privesc\AddCollectionSvc.cs" />
     <Compile Include="Modules\Privesc\AddProjectAdmin.cs" />
     <Compile Include="Modules\Privesc\GetPipelineSecrets.cs" />
+    <Compile Include="Modules\Privesc\GetVariableGroups.cs" />
     <Compile Include="Modules\Privesc\GetPipelineVars.cs" />
     <Compile Include="Modules\Privesc\GetServiceConnections.cs" />
-    <Compile Include="Modules\Privesc\GetVariableGroups.cs" />
     <Compile Include="Modules\Privesc\RemoveBuildAdmin.cs" />
     <Compile Include="Modules\Privesc\RemoveCollectionAdmin.cs" />
     <Compile Include="Modules\Privesc\RemoveCollectionBuildAdmin.cs" />
@@ -88,12 +88,12 @@
     <Compile Include="Modules\Recon\SearchRepo.cs" />
     <Compile Include="Modules\Recon\SearchUser.cs" />
     <Compile Include="Modules\Recon\Whoami.cs" />
+    <Compile Include="Objects\GroupVariable.cs" />
     <Compile Include="Objects\BuildVariable.cs" />
     <Compile Include="Objects\CodeResult.cs" />
     <Compile Include="Objects\File.cs" />
     <Compile Include="Objects\Group.cs" />
     <Compile Include="Objects\GroupMember.cs" />
-    <Compile Include="Objects\GroupVariable.cs" />
     <Compile Include="Objects\PatToken.cs" />
     <Compile Include="Objects\Project.cs" />
     <Compile Include="Objects\Repo.cs" />
@@ -119,7 +119,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="FodyWeavers.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Fody.4.0.2\build\Fody.targets" Condition="Exists('..\packages\Fody.4.0.2\build\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/ADOKit/Modules/Privesc/GetPipelineSecrets.cs
+++ b/ADOKit/Modules/Privesc/GetPipelineSecrets.cs
@@ -40,7 +40,7 @@ namespace ADOKit.Modules.Privesc
                     {
 
                         // create table header
-                        string tableHeader = string.Format("{0,30} | {1,30} | {2,20}", "Project Name", "Build Secret Name", "Build Secret Value");
+                        string tableHeader = string.Format("{0,30} | {1,30} | {2,30} | {3,50}", "Project Name", "Pipeline Name", "Pipeline Secret Name", "Pipeline Secret Value");
                         Console.WriteLine(tableHeader);
                         Console.WriteLine(new String('-', tableHeader.Length));
 
@@ -58,10 +58,10 @@ namespace ADOKit.Modules.Privesc
                             foreach (string buildUrl in buildDefinitionURLs)
                             {
 
-                                List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildSecrets(credential, buildUrl);
+                                List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildVarsOrSecrets(credential, buildUrl, true);
                                 foreach (Objects.BuildVariable var in variables)
                                 {
-                                    Console.WriteLine("{0,30} | {1,30} | {2,20}", proj.projectName, var.name, "[HIDDEN]");
+                                    Console.WriteLine("{0,30} | {1,30} | {2,30} | {3,50}", proj.projectName, var.pipelineName, var.name, "[HIDDEN]");
                                 }
                             }
 
@@ -76,7 +76,7 @@ namespace ADOKit.Modules.Privesc
                     else
                     {
                         // create table header
-                        string tableHeader = string.Format("{0,30} | {1,20}", "Build Secret Name", "Build Secret Value");
+                        string tableHeader = string.Format("{0,30} | {1,30} | {2,50}", "Pipeline Name", "Pipeline Secret Name", "Pipeline Secret Value");
                         Console.WriteLine(tableHeader);
                         Console.WriteLine(new String('-', tableHeader.Length));
 
@@ -87,10 +87,10 @@ namespace ADOKit.Modules.Privesc
                         foreach (string buildUrl in buildDefinitionURLs)
                         {
 
-                            List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildSecrets(credential, buildUrl);
+                            List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildVarsOrSecrets(credential, buildUrl, true);
                             foreach (Objects.BuildVariable var in variables)
                             {
-                                Console.WriteLine("{0,30} | {1,20}", var.name, "[HIDDEN]");
+                                Console.WriteLine("{0,30} | {1,30} | {2,20}", var.name, "[HIDDEN]");
                             }
                         }
 

--- a/ADOKit/Modules/Privesc/GetPipelineVars.cs
+++ b/ADOKit/Modules/Privesc/GetPipelineVars.cs
@@ -40,7 +40,7 @@ namespace ADOKit.Modules.Privesc
                     {
 
                         // create table header
-                        string tableHeader = string.Format("{0,30} | {1,30} | {2,50}", "Project Name", "Pipeline Var Name", "Pipeline Var Value");
+                        string tableHeader = string.Format("{0,30} | {1,30} | {2,30} | {3,50}", "Project Name", "Pipeline Name", "Pipeline Var Name", "Pipeline Var Value");
                         Console.WriteLine(tableHeader);
                         Console.WriteLine(new String('-', tableHeader.Length));
 
@@ -58,10 +58,10 @@ namespace ADOKit.Modules.Privesc
                             foreach (string buildUrl in buildDefinitionURLs)
                             {
 
-                                List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildVars(credential, buildUrl);
+                                List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildVarsOrSecrets(credential, buildUrl, false);
                                 foreach (Objects.BuildVariable var in variables)
                                 {
-                                    Console.WriteLine("{0,30} | {1,30} | {2,50}", proj.projectName, var.name, var.value);
+                                    Console.WriteLine("{0,30} | {1,30} | {2,30} | {3,50}", proj.projectName, var.pipelineName, var.name, var.value);
                                 }
                             }
 
@@ -76,7 +76,7 @@ namespace ADOKit.Modules.Privesc
                     else
                     {
                         // create table header
-                        string tableHeader = string.Format("{0,30} | {1,50}", "Pipeline Var Name", "Pipeline Var Value");
+                        string tableHeader = string.Format("{0,30} | {1,30} | {2,50}", "Pipeline Name", "Pipeline Var Name", "Pipeline Var Value");
                         Console.WriteLine(tableHeader);
                         Console.WriteLine(new String('-', tableHeader.Length));
 
@@ -87,10 +87,10 @@ namespace ADOKit.Modules.Privesc
                         foreach (string buildUrl in buildDefinitionURLs)
                         {
 
-                            List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildVars(credential, buildUrl);
+                            List<Objects.BuildVariable> variables = await Utilities.PipelineUtils.getBuildVarsOrSecrets(credential, buildUrl, false);
                             foreach (Objects.BuildVariable var in variables)
                             {
-                                Console.WriteLine("{0,30} | {1,50}", var.name, var.value);
+                                Console.WriteLine("{0,30} | {1,30} | {2,50}", var.pipelineName, var.name, var.value);
                             }
                         }
 

--- a/ADOKit/Modules/Recon/DownloadBuildLogs.cs
+++ b/ADOKit/Modules/Recon/DownloadBuildLogs.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+using System.Collections.Generic;
+using System.IO;
+using ADOKit.Utilities;
+using System.Threading;
+using System.Net.Http;
+
+namespace ADOKit.Modules.Recon
+{
+    class DownloadBuildLogs
+    {
+        public static async Task execute(string credential, string url, string project, string outfolder, bool reallyDownload)
+        {
+            // Generate module header
+            Console.WriteLine(ArgUtils.GenerateHeader("downloadbuildlogs", credential, url, "", project, "", ""));
+
+            // Verifies that the output folder exists
+            if (!Directory.Exists(outfolder + "/"))
+            {
+                throw new DirectoryNotFoundException($"The folder '{outfolder}' does not exist.");
+            }
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            // check if credentials provided are valid
+            Console.WriteLine("");
+            Console.WriteLine("[*] INFO: Checking credentials provided");
+            Console.WriteLine("");
+
+            // if creds valid, then provide message and continue
+            if (await WebUtils.credsValid(credential, url))
+            {
+                Console.WriteLine("[+] SUCCESS: Credentials provided are VALID.");
+                Console.WriteLine("");
+
+                try
+                {
+                    // count the number of build logs and lines
+                    int totalBuildLogs = 0;
+                    int totalLines = 0;
+
+                    // if user wants to dump build logs for all projects
+                    if (project.ToLower().Equals("all"))
+                    {
+
+                        // create table header
+                        string tableHeader = string.Format("{0,30} | {1,10} | {2,30} | {3,10} | {4,50}", "Project", "Build ID", "Build def. name", "# logs", "URL");
+                        Console.WriteLine(tableHeader);
+                        Console.WriteLine(new String('-', tableHeader.Length));
+
+                        // get a listing of all projects in the Azure DevOps instance
+                        List<Objects.Project> projectList = await ProjectUtils.getAllProjects(credential, url);
+
+                        // iterate through the list of projects and get all builds for each project
+                        foreach (Objects.Project proj in projectList)
+                        {
+                            List<Objects.Build> buildList = await BuildUtils.getBuilds(credential, url, proj.projectName);
+
+                            // in each project, get the list of builds (each pipeline run)
+                            foreach (Objects.Build build in buildList)
+                            {
+                                List<Objects.BuildLog> logList = await BuildUtils.getBuildLogs(credential, url, proj.projectName, build.ID);
+                                Console.WriteLine("{0,30} | {1,10} | {2,30} | {3,10} | {4,50}", proj.projectName, build.ID, build.buildDefinitionName, logList.Count, build.URL);
+                                totalBuildLogs += logList.Count;
+
+                                // finally, for each log, download it and store in the output folder
+                                foreach (Objects.BuildLog log in logList)
+                                {
+                                    if (reallyDownload)
+                                    {
+                                        await BuildUtils.downloadLog(credential, proj.projectName, outfolder, log);
+                                    }
+                                    else
+                                    {
+                                        totalLines += log.lineCount;
+                                    }
+                                }
+
+                            }
+
+                        }
+
+                    }
+                    // if user wants to only dump build logs for a certain project
+                    else
+                    {
+                        // create table header
+                        string tableHeader = string.Format("{0,10} | {1,30} | {2,10} | {3,50}", "Build ID", "Build def. name", "# logs", "URL");
+                        Console.WriteLine(tableHeader);
+                        Console.WriteLine(new String('-', tableHeader.Length));
+
+                        // get the list of builds (each pipeline run)
+                        List<Objects.Build> buildList = await BuildUtils.getBuilds(credential, url, project);
+                        foreach (Objects.Build build in buildList)
+                        {
+                            List<Objects.BuildLog> logList = await BuildUtils.getBuildLogs(credential, url, project, build.ID);
+                            Console.WriteLine("{0,10} | {1,30} | {2,10} | {3,50}", build.ID, build.buildDefinitionName, logList.Count, build.URL);
+                            totalBuildLogs += logList.Count;
+
+                            // finally, for each log, download it and store in the output folder
+                            foreach (Objects.BuildLog log in logList)
+                            {
+                                if (reallyDownload)
+                                {
+                                    await BuildUtils.downloadLog(credential, project, outfolder, log);
+                                }
+                                else
+                                {
+                                    totalLines += log.lineCount;
+                                }
+                            }
+
+                        }
+
+                    }
+
+                    Console.WriteLine("");
+                    if (!reallyDownload)
+                    {
+                        Console.WriteLine("[!] WARNING: If you really want to download the logs, use the /reallydownload flag.");
+                        Console.WriteLine($"[!] WARNING: This will download {totalBuildLogs} log files totalling {totalLines} lines of log.");
+                    }
+
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("[-] ERROR: " + ex.Message);
+                    Console.WriteLine("");
+                }
+
+
+            }
+
+            // if creds not valid, display message and return
+            else
+            {
+                Console.WriteLine("[-] ERROR: Credentials provided are INVALID. Check the credentials again.");
+                Console.WriteLine("");
+                return;
+            }
+        }
+
+
+    }
+}

--- a/ADOKit/Objects/Build.cs
+++ b/ADOKit/Objects/Build.cs
@@ -1,0 +1,19 @@
+﻿namespace ADOKit.Objects
+{
+    class Build
+    {
+
+        public int ID { get; set; }
+        public string URL { get; set; }
+        public string buildDefinitionName { get; set; }
+
+        public Build(int ID, string URL, string buildDefinitionName)
+        {
+            this.ID = ID;
+            this.URL = URL;
+            this.buildDefinitionName = buildDefinitionName;
+        }
+
+
+    }
+}

--- a/ADOKit/Objects/BuildLog.cs
+++ b/ADOKit/Objects/BuildLog.cs
@@ -1,0 +1,21 @@
+﻿namespace ADOKit.Objects
+{
+    class BuildLog
+    {
+
+        public int buildID { get; set; }
+        public int logID { get; set; }
+        public string logURL { get; set; }
+        public int lineCount { get; set; }
+
+        public BuildLog(int buildID, int logID, string logURL, int lineCount)
+        {
+            this.buildID = buildID;
+            this.logID = logID;
+            this.logURL = logURL;
+            this.lineCount = lineCount;
+        }
+
+
+    }
+}

--- a/ADOKit/Objects/BuildVariable.cs
+++ b/ADOKit/Objects/BuildVariable.cs
@@ -1,21 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ADOKit.Objects
+﻿namespace ADOKit.Objects
 {
     class BuildVariable
     {
 
         public string name { get; set; }
         public string value { get; set; }
+        public string pipelineName { get; set; }
 
-        public BuildVariable(string name, string value)
+        public BuildVariable(string name, string value, string pipelineName)
         {
             this.name = name;
             this.value = value;
+            this.pipelineName = pipelineName;
         }
 
 

--- a/ADOKit/Objects/GroupVariable.cs
+++ b/ADOKit/Objects/GroupVariable.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ADOKit.Objects
+﻿namespace ADOKit.Objects
 {
     class GroupVariable
     {

--- a/ADOKit/Utilities/BuildUtils.cs
+++ b/ADOKit/Utilities/BuildUtils.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using System.Text;
+using System.IO;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using ADOKit.Objects;
+
+namespace ADOKit.Utilities
+{
+    class BuildUtils
+    {
+        public static async Task<List<Build>> getBuilds(string credentials, string url, string project)
+        {
+
+            // this is the list of URLs to return
+            List<Build> projectBuilds = new List<Build>();
+
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            try
+            {
+
+
+                // web request to get all build definitions for a project
+                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/" + project + "/_apis/build/builds?api-version=7.1");
+                if (webRequest != null)
+                {
+
+                    // set header values
+                    webRequest.Method = "GET";
+                    webRequest.ContentType = "application/json";
+                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+
+                    // if cookie was provided
+                    if (credentials.ToLower().Contains("userauthentication="))
+                    {
+                        webRequest.Headers.Add("Cookie", "X-VSS-UseRequestRouting=True; " + credentials);
+
+                    }
+
+                    // otherwise PAT was provided
+                    else
+                    {
+                        webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+                    }
+
+
+                    // get web response
+                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+                    string content;
+                    var reader = new StreamReader(myWebResponse.GetResponseStream());
+                    content = reader.ReadToEnd();
+
+                    // parse the JSON output and display results
+                    dynamic jsonResult = JsonConvert.DeserializeObject(content);
+
+                    string buildURL = "";
+                    int buildID = 0;
+                    string buildDefName = "";
+
+                    // read the json results, first all groups
+                    foreach (var build in jsonResult.value)
+                    {
+                        buildID = build.id;
+                        buildURL = build.url;
+                        buildDefName = build.definition.name;
+
+                        projectBuilds.Add(new Build(buildID, buildURL, buildDefName));
+                    }
+
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("");
+            }
+
+
+            return projectBuilds;
+
+        }
+
+        public static async Task<List<BuildLog>> getBuildLogs(string credentials, string url, string project, int buildID)
+        {
+            // this is the list of log URLs to return
+            List<BuildLog> buildLogs = new List<BuildLog>();
+
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            try
+            {
+
+
+                // web request to get all build definitions for a project
+                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create($"{url}/{project}/_apis/build/builds/{buildID.ToString()}/logs?api-version=7.1");
+                if (webRequest != null)
+                {
+
+                    // set header values
+                    webRequest.Method = "GET";
+                    webRequest.ContentType = "application/json";
+                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+
+                    // if cookie was provided
+                    if (credentials.ToLower().Contains("userauthentication="))
+                    {
+                        webRequest.Headers.Add("Cookie", "X-VSS-UseRequestRouting=True; " + credentials);
+
+                    }
+
+                    // otherwise PAT was provided
+                    else
+                    {
+                        webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+                    }
+
+
+                    // get web response
+                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+                    string content;
+                    var reader = new StreamReader(myWebResponse.GetResponseStream());
+                    content = reader.ReadToEnd();
+
+                    // parse the JSON output and display results
+                    dynamic jsonResult = JsonConvert.DeserializeObject(content);
+
+                    string logURL = "";
+                    int logID = 0;
+                    int lineCount = 0;
+
+                    // read the json results, first all groups
+                    foreach (var log in jsonResult.value)
+                    {
+                        logID = log.id;
+                        logURL = log.url;
+                        lineCount = log.lineCount;
+
+                        buildLogs.Add(new BuildLog(buildID, logID, logURL, lineCount));
+                    }
+
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("");
+            }
+
+            return buildLogs;
+        }
+
+        public static async Task downloadLog(string credentials, string project, string outfolder, BuildLog log)
+        {
+            
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            try
+            {
+
+                // web request to download a single log
+                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(log.logURL);
+                if (webRequest != null)
+                {
+
+                    // set header values
+                    webRequest.Method = "GET";
+                    webRequest.ContentType = "application/json";
+                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+
+                    // if cookie was provided
+                    if (credentials.ToLower().Contains("userauthentication="))
+                    {
+                        webRequest.Headers.Add("Cookie", "X-VSS-UseRequestRouting=True; " + credentials);
+
+                    }
+
+                    // otherwise PAT was provided
+                    else
+                    {
+                        webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+                    }
+
+                    // get web response
+                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+
+                    // DEBUG for throttling, never occured to me... but who knows
+#if DEBUG
+                    for (int i = 0; i < myWebResponse.Headers.Count; ++i)
+                    {
+                        if (myWebResponse.Headers[i].StartsWith("X-RateLimit"))
+                        {
+                            Console.WriteLine("[!] WARNING: Throttling is occuring. Header Name:{0}, Value :{1}", myWebResponse.Headers.Keys[i], myWebResponse.Headers[i]);
+                        }
+                        else if (myWebResponse.Headers[i].StartsWith("Retry-After"))
+                        {
+                            Console.WriteLine("[!] WARNING: Throttling is occuring. Header Name:{0}, Value :{1}", myWebResponse.Headers.Keys[i], myWebResponse.Headers[i]);
+                        }
+                    }
+#endif
+
+                    string content;
+                    var reader = new StreamReader(myWebResponse.GetResponseStream());
+                    content = reader.ReadToEnd();
+
+                    // store to file with the filename containing all useful infos
+                    string filePath = $"{outfolder}/{project}_{log.buildID}_{log.logID}.txt";
+                    System.IO.File.WriteAllText(filePath, content);
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("");
+            }
+
+        }
+    }
+}

--- a/ADOKit/Utilities/PipelineUtils.cs
+++ b/ADOKit/Utilities/PipelineUtils.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using ADOKit.Objects;
 
-
 namespace ADOKit.Utilities
 {
     class PipelineUtils
@@ -130,9 +129,8 @@ namespace ADOKit.Utilities
         }
 
 
-
         // get a list of build variables from a project build definition
-        public static async Task<List<BuildVariable>> getBuildVars(string credentials, string buildDefURL)
+        public static async Task<List<BuildVariable>> getBuildVarsOrSecrets(string credentials, string buildDefURL, bool getSecrets)
         {
 
             // this is the list of build variables to return
@@ -178,87 +176,35 @@ namespace ADOKit.Utilities
                     var reader = new StreamReader(myWebResponse.GetResponseStream());
                     content = reader.ReadToEnd();
 
-
                     // parse the JSON output and display results
-                    JsonTextReader jsonResult = new JsonTextReader(new StringReader(content));
+                    dynamic jsonResult = JsonConvert.DeserializeObject(content);
 
-                    string propName = "";
-                    string name = "";
-                    string value = "";
-                    string propVarName = ""; // used to track whether we are in variables section
+                    string pipelineName = jsonResult.name;
+                    string variableName = "";
+                    string variableValue = "";
 
-
-                    // read the json results
-                    while (jsonResult.Read())
+                    // read the json results if there are some variables
+                    if (jsonResult.variables != null)
                     {
-                        switch (jsonResult.TokenType.ToString())
+                        foreach (var variable in jsonResult.variables)
                         {
-                            case "StartObject":
-                                break;
-                            case "EndObject":
-
-                                // add build variable to the list if it has all the attributes needed and we didn't already add it
-                                if (!doesBuildVariableAlreadyExist(name, value, buildVariables) && value != "" && name != "")
+                            variableName = variable.Name;
+                            variableValue = variable.Value.value;
+                            // don't add the same variable multiple times or empty vars
+                            if (variableValue != "" && !doesBuildVariableAlreadyExist(pipelineName, variableName, variableValue, buildVariables))
+                            {
+                                // only input either the var or the secret, not both
+                                if (variable.Value.isSecret == "true" && getSecrets)
                                 {
-                                    buildVariables.Add(new BuildVariable(name, value));
-
-                                    // reset values after build variable item has been added
-                                    buildDefURL = "";
-                                    name = "";
-                                    value = "";
+                                    buildVariables.Add(new BuildVariable(variableName, variableValue, pipelineName));
                                 }
-
-                                break;
-                            case "StartArray":
-                                break;
-                            case "EndArray":
-                                break;
-                            case "PropertyName":
-
-                                // at this point we know we are at start of variables section
-                                if (propName.Equals("variables"))
+                                else if (variable.Value.isSecret != "true" && !getSecrets)
                                 {
-                                    propVarName = jsonResult.Value.ToString();
-
+                                    buildVariables.Add(new BuildVariable(variableName, variableValue, pipelineName));
                                 }
-
-                                // at this point we know we are at end of variables so we can set it back to blank
-                                if (propName.Equals("properties"))
-                                {
-                                    propVarName = "";
-
-                                }
-
-                                propName = jsonResult.Value.ToString();
-
-                                // only get a variable name if we are in the variables block and it isn't a value
-                                if (propVarName != "")
-                                {
-
-                                    if(propName != "value")
-                                    {
-                                        name = jsonResult.Value.ToString();
-                                    }
-
-                                }
-                                break;
-                            case "String":
-
-                                // only print if we are in the variables block
-                                if (propVarName != "")
-                                {
-                                    value = jsonResult.Value.ToString();
-                                }
-                                break;
-                            case "Boolean":
-                                break;
-                            case "Date":
-                                break;
-                            default:
-                                break;
+                            }
 
                         }
-
                     }
 
                 }
@@ -275,169 +221,15 @@ namespace ADOKit.Utilities
             return buildVariables;
 
         }
-
-
-        // get a list of build secrets from a project build definition
-        public static async Task<List<BuildVariable>> getBuildSecrets(string credentials, string buildDefURL)
-        {
-
-            // this is the list of build variables to return
-            List<BuildVariable> buildVariables = new List<BuildVariable>();
-
-
-            // ignore SSL errors
-            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
-            ServicePointManager.Expect100Continue = true;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-
-            try
-            {
-
-
-                // web request to get all build variables for a build definition
-                HttpWebRequest webRequest = (HttpWebRequest)System.Net.WebRequest.Create(buildDefURL);
-                if (webRequest != null)
-                {
-
-                    // set header values
-                    webRequest.Method = "GET";
-                    webRequest.ContentType = "application/json";
-                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
-
-                    // if cookie was provided
-                    if (credentials.ToLower().Contains("userauthentication="))
-                    {
-                        webRequest.Headers.Add("Cookie", "X-VSS-UseRequestRouting=True; " + credentials);
-
-                    }
-
-                    // otherwise PAT was provided
-                    else
-                    {
-                        webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
-                    }
-
-
-                    // get web response
-                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
-                    string content;
-                    var reader = new StreamReader(myWebResponse.GetResponseStream());
-                    content = reader.ReadToEnd();
-
-
-                    // parse the JSON output and display results
-                    JsonTextReader jsonResult = new JsonTextReader(new StringReader(content));
-
-                    string propName = "";
-                    string name = "";
-                    string value = "";
-                    string propVarName = ""; // used to track whether we are in variables section
-
-
-                    // read the json results
-                    while (jsonResult.Read())
-                    {
-                        switch (jsonResult.TokenType.ToString())
-                        {
-                            case "StartObject":
-                                break;
-                            case "EndObject":
-                                break;
-                            case "StartArray":
-                                break;
-                            case "EndArray":
-                                break;
-                            case "PropertyName":
-
-                                // at this point we know we are at start of variables section
-                                if (propName.Equals("variables"))
-                                {
-                                    propVarName = jsonResult.Value.ToString();
-
-                                }
-
-                                // at this point we know we are at end of variables so we can set it back to blank
-                                if (propName.Equals("properties"))
-                                {
-                                    propVarName = "";
-
-                                }
-
-                                propName = jsonResult.Value.ToString();
-
-                                // only get a variable name if we are in the variables block and it isn't a value
-                                if (propVarName != "")
-                                {
-
-                                    // if we have gotten to a build secret, then assign it appropriatelly
-                                    if(propName == "isSecret")
-                                    {
-                                        value = ""; // value is going to be null, so assign blank string
-
-                                        // add build secret to the list if it has all the attributes needed and we didn't already add it
-                                        if (!doesBuildVariableAlreadyExist(name, value, buildVariables) && value == "" && name != "")
-                                        {
-                                            buildVariables.Add(new BuildVariable(name, value));
-
-                                            // reset values after build secret item has been added
-                                            buildDefURL = "";
-                                            name = "";
-                                            value = "";
-                                        }
-                                    }
-
-                                    if (propName != "value" && propName != "isSecret")
-                                    {
-                                        name = jsonResult.Value.ToString();
-
-                                    }
-
-                                }
-                                break;
-                            case "String":
-
-                                // only print if we are in the variables block
-                                if (propVarName != "")
-                                {
-                                    value = jsonResult.Value.ToString();
-                                }
-                                
-                                break;
-                            case "Boolean":
-                                break;
-                            case "Date":
-                                break;
-                            default:
-                                break;
-
-                        }
-
-                    }
-
-                }
-
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("");
-                Console.WriteLine("[-] ERROR: " + ex.Message);
-                Console.WriteLine("");
-            }
-
-
-            return buildVariables;
-
-        }
-
 
         // determine whether we already have that build variable
-        public static bool doesBuildVariableAlreadyExist(string name, string value, List<BuildVariable> buildList)
+        public static bool doesBuildVariableAlreadyExist(string pipelineName, string name, string value, List<BuildVariable> buildList)
         {
             bool doesItExist = false;
 
             foreach (Objects.BuildVariable variable in buildList)
             {
-                if (variable.name.Equals(name) && variable.value.Equals(value))
+                if (variable.pipelineName.Equals(pipelineName) && variable.name.Equals(name) && variable.value.Equals(value))
                 {
                     doesItExist = true;
                 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Full details on the techniques used by ADOKit are in the X-Force Red [whitepaper
     - [Search Groups](#search-groups)
     - [Get Group Members](#get-group-members)
     - [Get Project Permissions](#get-project-permissions)
+	- [Download Build Logs](#download-build-logs)
   - Persistence
     - [Create PAT](#create-pat)
     - [List PATs](#list-pats)
@@ -110,6 +111,7 @@ Take the below steps to setup Visual Studio in order to compile the project your
   * <b>searchgroup</b> - Search for a given group
   * <b>getgroupmembers</b> - List all group members for a given group
   * <b>getpermissions</b> - Get the permissions for who has access to a given project
+  * <b>downloadbuildlogs</b> - Download the build logs for one or all projects
 * Persistence
   * <b>createpat</b> - Create personal access token for user
   * <b>listpat</b> - List personal access tokens for user
@@ -145,6 +147,8 @@ Take the below steps to setup Visual Studio in order to compile the project your
 * <b>/user:</b> - Perform an action against a specific user. Not applicable to all modules.
 * <b>/id:</b> - Used with persistence modules to perform an action against a specific token ID. Not applicable to all modules.
 * <b>/group:</b> - Perform an action against a specific group. Not applicable to all modules.
+* <b>/reallydownload</b> - Boolean flag, perform all the requests to download build logs (default is to count them first). Only applicable to the `downloadbuildlogs` module.
+* <b>/outfolder</b> - Output folder, only applicable to the `downloadbuildlogs` module.
 
 ## Authentication Options
 
@@ -178,6 +182,7 @@ Recon | `listgroup` |  No |
 Recon | `searchgroup` |  No |
 Recon | `getgroupmembers` |  No |
 Recon | `getpermissions` |  No |
+Recon | `downloadbuildlogs` | No |
 Persistence | `createpat` |  No | 
 Persistence | `listpat` |  No | 
 Persistence | `removepat` |  No | 
@@ -1142,6 +1147,62 @@ GROUP NAME: [MaraudersMap]\Readers
 4/4/23 13:11:18 Finished execution of getpermissions
 
 ```
+
+
+### Download Build Logs
+
+#### Use Case
+
+> *Download the logs of all the pipeline runs (build logs). You can then search offline for information and/or secrets.*
+
+#### Syntax
+
+Provide the `downloadbuildlogs` module along with a `/project:` for a given project to download all the build logs for this project. If you would like to download them for all projects, specify `all` in the `/project:` argument.
+
+By default, this module only counts the number of logs and the corresponding lines that you would download. We recommend to start with that, because the number of HTTP request and the amount of data downloaded can quickly become large. If you have counted and still want to proceed with the download, add the `/reallydownload` flag to the command line. Note that you can also specify a `/outputfolder:` parameter to specify where to place the downloaded files. Otherwise, the current folder will be used.
+
+`ADOKit.exe downloadbuildlogs /credential:apiKey /url:https://dev.azure.com/organizationName /project:"someProject"`
+
+`ADOKit.exe downloadbuildlogs /credential:apiKey /url:https://dev.azure.com/organizationName /project:"all"`
+
+`ADOKit.exe downloadbuildlogs /credential:apiKey /url:https://dev.azure.com/organizationName /project:"someProject" /reallydownload`
+
+`ADOKit.exe downloadbuildlogs /credential:apiKey /url:https://dev.azure.com/organizationName /project:"someProject" /reallydownload /outputfolder:"output"`
+
+`ADOKit.exe downloadbuildlogs /credential:apiKey /url:https://dev.azure.com/organizationName /project:"all"`
+
+
+#### Example Output
+
+```
+C:\> .\ADOKit.exe downloadbuildlogs /outfolder:"output" /project:"someProject" /url:"https://dev.azure.com/organizationName" /credential:apiKey
+
+==================================================
+Module:         downloadbuildlogs
+Auth Type:      API Key
+Project:        OffensivePipeline
+Target URL:     https://dev.azure.com/organizationName/
+
+Timestamp:      31/05/2024 11:56:39
+==================================================
+
+
+[*] INFO: Checking credentials provided
+
+[+] SUCCESS: Credentials provided are VALID.
+
+  Build ID |                Build def. name |     # logs |                                                URL
+-------------------------------------------------------------------------------------------------------------
+       712 |             Release.Something1 |         67 | https://dev.azure.com/organizationName/bff4b5d2-ef36-4b5f-b26b-d83d964c8e00/_apis/build/Builds/712
+       711 |             Release.Something2 |         49 | https://dev.azure.com/organizationName/bff4b5d2-ef36-4b5f-b26b-d83d964c8e00/_apis/build/Builds/711
+       710 |             Release.Something3 |         49 | https://dev.azure.com/organizationName/bff4b5d2-ef36-4b5f-b26b-d83d964c8e00/_apis/build/Builds/710
+       ...
+
+[!] WARNING: If you really want to download the logs, use the /reallydownload flag.
+[!] WARNING: This will download 3065 log files totalling 257082 lines of log.
+```
+
+
 
 ### Add Project Admin
 


### PR DESCRIPTION
This is a quality of life update. It makes variable enumeration easier. I now include the pipeline name for each variable on top of the project name. This proves very useful when you have many many pipelines in a single project and you have to search all of them for the correct variable.

There's also some refactor of the code to simplify and parse JSON results in a more convenient way.