### PR TITLE
Feature add: New listorgs recon module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/ADOKit/.vs
+/ADOKit/bin/Debug
+/ADOKit/obj/Debug
+/.vs/ADOKit
+/packages
+*.user

--- a/ADOKit/ADOKit.cs
+++ b/ADOKit/ADOKit.cs
@@ -19,7 +19,7 @@ namespace ADOKit
         private static string search = "";
         private static string id = "";
         private static string sshKey = "";
-        private static List<string> approvedModules = new List<string> { "check", "whoami", "listrepo", "searchrepo", "listproject", "searchproject", "searchcode", "searchfile", "listuser", "searchuser", "listgroup", "searchgroup", "getgroupmembers", "getpermissions", "createpat", "removepat", "listpat", "createsshkey", "removesshkey", "listsshkey", "addprojectadmin", "removeprojectadmin", "addbuildadmin", "removebuildadmin", "addcollectionadmin", "removecollectionadmin", "addcollectionbuildadmin", "removecollectionbuildadmin", "addcollectionbuildsvc", "removecollectionbuildsvc", "addcollectionsvc", "removecollectionsvc", "getpipelinevars", "getpipelinesecrets", "getvariablegroups", "getserviceconnections", "creds", "getbuildlogs", "listbuildlogs", "searchbuildlogs", "listteam", "searchteam", "getteammembers" };
+        private static List<string> approvedModules = new List<string> { "check", "whoami", "listorgs", "listrepo", "searchrepo", "listproject", "searchproject", "searchcode", "searchfile", "listuser", "searchuser", "listgroup", "searchgroup", "getgroupmembers", "getpermissions", "createpat", "removepat", "listpat", "createsshkey", "removesshkey", "listsshkey", "addprojectadmin", "removeprojectadmin", "addbuildadmin", "removebuildadmin", "addcollectionadmin", "removecollectionadmin", "addcollectionbuildadmin", "removecollectionbuildadmin", "addcollectionbuildsvc", "removecollectionbuildsvc", "addcollectionsvc", "removecollectionsvc", "getpipelinevars", "getpipelinesecrets", "getvariablegroups", "getserviceconnections", "creds", "getbuildlogs", "listbuildlogs", "searchbuildlogs", "listteam", "searchteam", "getteammembers" };
 
 
 
@@ -41,7 +41,7 @@ namespace ADOKit
                 module = args[0].ToLower(); // get the module by the first argument given
 
                 // if url is not set, display message and exit
-                if (!argDict.ContainsKey("url"))
+                if (!argDict.ContainsKey("url") && !module.Equals("listorgs"))
                 {
                     Console.WriteLine("");
                     Console.WriteLine("[-] ERROR: Must supply a URL. See the README.");
@@ -134,7 +134,9 @@ namespace ADOKit
                 // if all is good, proceed to run appropriate module
                 switch (module)
                 {
-
+                    case "listorgs":
+                        await Modules.Recon.ListOrgs.execute(credential, argDict);
+                        break;
                     case "check":
                         await Modules.Recon.Check.execute(credential, url);
                         break;

--- a/ADOKit/ADOKit.csproj
+++ b/ADOKit/ADOKit.csproj
@@ -39,11 +39,66 @@
     <Reference Include="Costura, Version=3.3.3.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.3.3.3\lib\net40\Costura.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.Memory, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Memory.9.0.0\lib\net462\Microsoft.Bcl.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.TimeProvider, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.TimeProvider.8.0.1\lib\net462\Microsoft.Bcl.TimeProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.2.1.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=8.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.8.6.1\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=8.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.8.6.1\lib\net472\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=8.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.8.6.1\lib\net472\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=8.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.8.6.1\lib\net472\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=6.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.6.0.2\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=8.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.8.6.1\lib\net472\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -82,6 +137,7 @@
     <Compile Include="Modules\Recon\GetTeamMembers.cs" />
     <Compile Include="Modules\Recon\ListBuildLogs.cs" />
     <Compile Include="Modules\Recon\ListGroup.cs" />
+    <Compile Include="Modules\Recon\ListOrgs.cs" />
     <Compile Include="Modules\Recon\ListProject.cs" />
     <Compile Include="Modules\Recon\ListRepo.cs" />
     <Compile Include="Modules\Recon\ListTeam.cs" />
@@ -103,6 +159,7 @@
     <Compile Include="Objects\Group.cs" />
     <Compile Include="Objects\GroupMember.cs" />
     <Compile Include="Objects\GroupVariable.cs" />
+    <Compile Include="Objects\Org.cs" />
     <Compile Include="Objects\PatToken.cs" />
     <Compile Include="Objects\Project.cs" />
     <Compile Include="Objects\Repo.cs" />
@@ -118,6 +175,8 @@
     <Compile Include="Utilities\CodeUtils.cs" />
     <Compile Include="Utilities\FileUtils.cs" />
     <Compile Include="Utilities\GroupUtils.cs" />
+    <Compile Include="Utilities\JwtUtils.cs" />
+    <Compile Include="Utilities\OrgUtils.cs" />
     <Compile Include="Utilities\PatUtils.cs" />
     <Compile Include="Utilities\PipelineUtils.cs" />
     <Compile Include="Utilities\ProjectUtils.cs" />

--- a/ADOKit/App.config
+++ b/ADOKit/App.config
@@ -1,6 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/ADOKit/Modules/Recon/ListOrgs.cs
+++ b/ADOKit/Modules/Recon/ListOrgs.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+
+namespace ADOKit.Modules.Recon
+{
+    class ListOrgs
+    {
+        public static async Task execute(string credential, Dictionary<string, string> args)
+        {
+
+            // Determine the mode: "aad" if specified, otherwise default.
+            string mode = args.ContainsKey("mode") ? args["mode"].ToLower() : "";
+
+            // Determine which aex endpoint to use based on operator input.
+            string aexEndpoint = args.ContainsKey("endpoint") ? args["endpoint"].ToLower() : ""; 
+
+
+
+            // do some error check. endpoint should not be defined and the only supported mode is aad.
+            // sanity checks
+            if(string.IsNullOrEmpty(mode) && !string.IsNullOrEmpty(aexEndpoint))
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: Custom endpoint not supported for default mode.");
+                Console.WriteLine("");
+                return;
+            }
+
+            if(!string.IsNullOrEmpty(mode) && mode != "aad")
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: Unsupported mode.");
+                Console.WriteLine("");
+                return;
+            }
+
+
+            if (string.IsNullOrEmpty(aexEndpoint))
+            {
+                aexEndpoint = "aexprodcus1"; // default AEX endpoint for AAD mode; ensure it matches the "aexEndpoint" variable in getAadOrgs for consistent logging and traffic.
+            }
+
+
+            // Choose the appropriate host based on mode.
+            string host = (mode == "aad") ? $"https://{aexEndpoint}.vsaex.visualstudio.com" : "https://app.vssps.visualstudio.com";
+
+
+            // Generate module header
+            Console.WriteLine(Utilities.ArgUtils.GenerateHeader("listorgs", credential, host, "", "", "", ""));
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            // check if credentials provided are valid
+            Console.WriteLine("");
+            Console.WriteLine("[*] INFO: Checking credentials provided");
+            Console.WriteLine("");
+
+            // if creds valid, then provide message and continue
+            if (Utilities.JwtUtils.isValid(credential))
+            {
+                Console.WriteLine("[+] SUCCESS: Credentials provided are VALID.");
+                Console.WriteLine("");
+
+                try
+                {
+
+                    List<Objects.Org> orgList;
+
+
+                    if (mode == "aad")
+                    {
+                        // create table header
+                        //The given organization name is not valid. Organization names must start with a letter or number, followed by letters, numbers or hyphens, and must end with a letter or number.
+                        string tableHeader = string.Format("{0,40} | {1,40} | {2,50} | {3,40}", "Organization ID", "Organization Name", "URL", "Owner");
+                        Console.WriteLine(tableHeader);
+                        Console.WriteLine(new String('-', tableHeader.Length));
+
+                        // get a listing of all organizations access token has access to in the Azure DevOps instance
+                        orgList = await Utilities.OrgUtils.getAadOrgs(credential, aexEndpoint);
+
+                        // iterate through the list of orgs and list them
+                        foreach (Objects.Org org in orgList)
+                        {
+
+                            Console.WriteLine("{0,40} | {1,40} | {2,50} | {3,40}", org.orgID, org.orgName, org.url, org.owner);
+
+                        }
+
+                        //Console.WriteLine("");
+
+                    }
+                    else
+                    {
+                        // create table header
+                        //The given organization name is not valid. Organization names must start with a letter or number, followed by letters, numbers or hyphens, and must end with a letter or number.
+                        string tableHeader = string.Format("{0,40} | {1,40}", "Organization ID", "Organization Name");
+                        Console.WriteLine(tableHeader);
+                        Console.WriteLine(new String('-', tableHeader.Length));
+
+                        // get a listing of all organizations access token has access to in the Azure DevOps instance
+                        orgList = await Utilities.OrgUtils.getAccessibleOrgs(credential);
+
+                        // iterate through the list of orgs and list them
+                        foreach (Objects.Org org in orgList)
+                        {
+
+                            Console.WriteLine("{0,40} | {1,40}", org.orgID, org.orgName);
+
+                        }
+
+                        Console.WriteLine("");
+                        Console.WriteLine("");
+                    }
+
+
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("[-] ERROR: " + ex.Message);
+                    Console.WriteLine("[-] ERROR: " + ex.StackTrace);
+                    Console.WriteLine("");
+                }
+
+            }
+
+            // if creds not valid, display message and return
+            else
+            {
+                Console.WriteLine("[-] ERROR: Credentials provided are INVALID. Check the credentials again.");
+                Console.WriteLine("");
+                return;
+            }
+        }
+    }
+}

--- a/ADOKit/Objects/Org.cs
+++ b/ADOKit/Objects/Org.cs
@@ -1,0 +1,19 @@
+﻿namespace ADOKit.Objects
+{
+    class Org
+    {
+
+        public string orgName { get; set; }
+        public string orgID { get; set; }
+        public string url { get; set; }
+        public string owner { get; set; }
+
+        public Org(string orgName, string orgID, string url = "", string owner = "")
+        {
+            this.orgName = orgName;
+            this.orgID = orgID;
+            this.url = url;
+            this.owner = owner;
+        }
+    }
+}

--- a/ADOKit/Properties/AssemblyInfo.cs
+++ b/ADOKit/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3")]
-[assembly: AssemblyFileVersion("1.3")]
+[assembly: AssemblyVersion("1.4")]
+[assembly: AssemblyFileVersion("1.4")]

--- a/ADOKit/Properties/AssemblyInfo.cs
+++ b/ADOKit/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ADOKit")]
-[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/ADOKit/Utilities/JwtUtils.cs
+++ b/ADOKit/Utilities/JwtUtils.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.IdentityModel.Tokens.Jwt;
+
+
+namespace ADOKit.Utilities
+{
+    class JwtUtils
+    {
+        // https://stackoverflow.com/a/74698169
+        // Check for Expiration & Audience
+        public static bool isValid(string token)
+        {  
+            JwtSecurityToken jwtSecurityToken;
+            try
+            {
+                jwtSecurityToken = new JwtSecurityToken(token);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("[-] ERROR: The provided token is not a valid JWT. PATs not supported for this module.");
+                return false;
+            }
+
+            bool notExpired = jwtSecurityToken.ValidTo > DateTime.UtcNow;
+            bool hasValidAudience = jwtSecurityToken.Audiences.Contains("499b84ac-1321-427f-aa17-267ca6975798") || jwtSecurityToken.Audiences.Contains("https://management.core.windows.net/");
+
+            if(!notExpired)
+            {
+                Console.WriteLine("[-] ERROR: JWT Token Expired!");
+            }
+            if (!hasValidAudience)
+            {
+                Console.WriteLine("[-] ERROR: JWT Invalid Audience!");
+            }
+
+            return notExpired && hasValidAudience;
+        }
+
+        public static string getTenantID(string token)
+        {
+            JwtSecurityToken jwtSecurityToken;
+            try
+            {
+                jwtSecurityToken = new JwtSecurityToken(token);
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: The provided token is not a valid JWT. PATs not supported.");
+                Console.WriteLine("");
+                return "";
+            }
+
+            // Extract the "tid" claim value
+            var tenantId = jwtSecurityToken.Claims.FirstOrDefault(c => c.Type == "tid")?.Value;
+
+            return tenantId ?? "";
+        }
+    }
+}

--- a/ADOKit/Utilities/OrgUtils.cs
+++ b/ADOKit/Utilities/OrgUtils.cs
@@ -1,0 +1,345 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
+using System.IO;
+using ADOKit.Objects;
+
+namespace ADOKit.Utilities
+{
+    class OrgUtils
+    {
+        // Retrieve memberId
+        public static async Task<string> getMemberId(string credentials)
+        {
+            string memberId = "";
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            // parse the JSON output and display results
+            JsonTextReader jsonResult;
+
+            try
+            {
+
+                string url = "https://app.vssps.visualstudio.com";
+                string content = "";
+
+                // web request to get memberId
+                HttpWebRequest webRequest = null;
+                webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + "/_apis/profile/profiles/me?api-version=7.1");
+
+
+                if (webRequest != null)
+                {
+
+                    // set header values
+                    webRequest.Method = "GET";
+                    webRequest.ContentType = "application/json";
+                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+                    webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+
+                    // get web response
+                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+
+                    var reader = new StreamReader(myWebResponse.GetResponseStream());
+                    content = reader.ReadToEnd();
+                }
+
+
+                // parse the JSON output and display results
+                jsonResult = new JsonTextReader(new StringReader(content));
+                string propName = "";
+                // read the json results
+                while (jsonResult.Read())
+                {
+                    switch (jsonResult.TokenType.ToString())
+                    {
+                        case "StartObject":
+                            break;
+                        case "EndObject":
+                            break;
+                        case "StartArray":
+                            break;
+                        case "EndArray":
+                            break;
+                        case "PropertyName":
+                            propName = jsonResult.Value.ToString();
+                            break;
+                        case "String":
+                            // grab the memberId
+                            if (propName.ToLower().Equals("publicalias"))
+                            {
+                                memberId = jsonResult.Value.ToString();
+                            }
+                            break;
+                        case "Integer":
+                            break;
+                        default:
+                            break;
+
+                    }
+
+                }
+            }
+
+            catch (Exception ex)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("[-] ERROR: " + ex.StackTrace);
+                Console.WriteLine("");
+            }
+
+
+
+            return memberId;
+        }
+
+
+        // Retrieve the list of all Azure DevOps organizations accessible with the current access token.
+        public static async Task<List<Org>> getAccessibleOrgs(string credentials)
+        {
+            // this is the list of orgs to return
+            List<Org> orgList = new List<Org>();
+
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+	        // parse the JSON output and display results
+	        JsonTextReader jsonResult;
+	    
+	        string orgName = "";
+            string orgID = "";
+            string content = "";
+            string propName = "";
+
+            string url = "https://app.vssps.visualstudio.com";
+
+            try
+            {
+                // Retrieve memberId/publicAlias via REST API
+                string memberId = await getMemberId(credentials); 
+
+                // Web request to get Organizations we have access to.
+                // https://learn.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-7.1&tabs=HTTP
+                HttpWebRequest webRequest = null;
+                webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + $"/_apis/accounts?memberId={memberId}?api-version=7.1");
+
+
+                if (webRequest != null)
+                {
+
+                    // set header values
+                    webRequest.Method = "GET";
+                    webRequest.ContentType = "application/json";
+                    webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+                    webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+
+                    // get web response
+                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+
+                    var reader = new StreamReader(myWebResponse.GetResponseStream());
+                    content = reader.ReadToEnd();
+                }
+
+                // parse the JSON output and display results
+                jsonResult = new JsonTextReader(new StringReader(content));
+                
+                // read the json results
+                while (jsonResult.Read())
+                {
+                    //Console.WriteLine($"Token: {jsonResult.TokenType}, Value: {jsonResult.Value}");
+                    switch (jsonResult.TokenType.ToString())
+                    {
+                        case "StartObject":
+                            break;
+                        case "EndObject":
+                            
+                            if (orgID != "" && orgName != "")
+                            {
+                                orgList.Add(new Org(orgName, orgID));
+                                orgID = "";
+                                orgName = "";
+                            }
+                            break;
+                        case "StartArray":
+                            break;
+                        case "EndArray":
+                            break;
+                        case "PropertyName":
+                            propName = jsonResult.Value.ToString();
+                            break;
+                        case "String":
+                            // grab the org id (AccountId)
+                            if (propName.ToLower().Equals("accountid"))
+                            {
+                                orgID = jsonResult.Value.ToString();
+                            }
+                            // grab the org name (AccountName)
+                            if (propName.ToLower().Equals("accountname"))
+                            {
+                                orgName = jsonResult.Value.ToString();
+                            }
+                            break;
+                        case "Integer":
+                            break;
+                        default:
+                            break;
+
+                    }
+
+                }
+
+            }
+
+            catch (Exception ex)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("[-] ERROR: " + ex.StackTrace);
+                Console.WriteLine("");
+            }
+
+            return orgList;
+        }
+
+
+        // Retrieve the list of all Azure DevOps organizations registered in Azure Active Directory.
+        public static async Task<List<Org>> getAadOrgs(string credentials, string aexEndpoint)
+        {
+            // this is the list of orgs to return
+            List<Org> orgList = new List<Org>();
+
+            // ignore SSL errors
+            ServicePointManager.ServerCertificateValidationCallback = delegate (object s, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) { return true; };
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
+            // Extract tenant id (tid) claim from the JWT.
+            string tenantID = JwtUtils.getTenantID(credentials);
+            if (string.IsNullOrEmpty(tenantID))
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: Tenant ID (tid) not found in the token.");
+                Console.WriteLine("");
+
+                return orgList;
+            }
+
+
+
+
+            /*
+            
+            Construct the endpoint URL.
+            The endpoint was selected at random, valid endpoints include:
+            aexprodcus1, aexprodeus21, aexprodea1, aexprodweu1, aexprodeau1, aexprodsin1, etc.
+            Additional endpoints may be found via Google dorks or by inspecting the "X-VSS-DeploymentAffinity" cookie from aex.dev.azure.com.
+            
+            */
+
+            string endpoint = "";
+            if (string.IsNullOrEmpty(aexEndpoint))
+            {
+                aexEndpoint = "aexprodcus1"; // default, if operator doesn't supply custom endpoint.
+            }
+            else
+            {
+                endpoint = aexEndpoint;
+            }
+            
+            string url = $"https://{endpoint}.vsaex.visualstudio.com";
+
+            try
+            {
+                HttpWebRequest webRequest = null;
+                webRequest = (HttpWebRequest)System.Net.WebRequest.Create(url + $"/_apis/EnterpriseCatalog/Organizations?tenantId={tenantID}");
+
+                // set header values
+                webRequest.Method = "GET";
+                webRequest.ContentType = "application/json";
+                webRequest.UserAgent = "ADOKit-21e233d4334f9703d1a3a42b6e2efd38";
+                //webRequest.Accept = "application/octet-stream;api-version=5.2-preview.1;excludeUrls=true;enumsAsNumbers=true;msDateFormat=true;noArrayWrap=true"; //Not necessary during testing. YMMV.
+                webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
+
+                string content = "";
+                if (webRequest != null)
+                {
+
+                    HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();
+                    var reader = new StreamReader(myWebResponse.GetResponseStream());
+                    content = reader.ReadToEnd();
+                }
+
+                // parse the CSV output and display results
+                using (StringReader sr = new StringReader(content))
+                {
+                    string line;
+                    bool headerParsed = false;
+                    while ((line = sr.ReadLine()) != null)
+                    {
+                        // Skip the header line.
+                        if (!headerParsed)
+                        {
+                            headerParsed = true;
+                            continue;
+                        }
+                        if (string.IsNullOrWhiteSpace(line))
+                            continue;
+
+                        // Split the CSV line.
+                        string[] parts = line.Split(',');
+                        // Expect at least 4 parts: Org Id, Org Name, Url, Owner.
+                        if (parts.Length >= 4)
+                        {
+                            string orgId = parts[0].Trim();
+                            string orgName = parts[1].Trim();
+                            string orgUrl = parts[2].Trim();
+                            string orgOwner = parts[3].Trim();
+
+                            orgList.Add(new Org(orgName, orgId, orgUrl, orgOwner));
+                        }
+                    }
+                }
+
+
+            }
+            catch (WebException webEx)
+            {
+                if (webEx.Response is HttpWebResponse httpResponse && httpResponse.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("[-] ERROR: 401 Unauthorized. Specify a valid aex endpoint.");
+                    Console.WriteLine("");
+                }
+                else
+                {
+                    Console.WriteLine("");
+                    Console.WriteLine("[-] ERROR: " + webEx.Message);
+                    Console.WriteLine("[-] ERROR: " + webEx.StackTrace);
+                    Console.WriteLine("");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("");
+                Console.WriteLine("[-] ERROR: " + ex.Message);
+                Console.WriteLine("[-] ERROR: " + ex.StackTrace);
+                Console.WriteLine("");
+            }
+
+            return orgList;
+        }
+    }
+}

--- a/ADOKit/Utilities/WebUtils.cs
+++ b/ADOKit/Utilities/WebUtils.cs
@@ -26,6 +26,7 @@ namespace ADOKit.Utilities
             ServicePointManager.Expect100Continue = true;
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
+
             try
             {
 
@@ -47,17 +48,17 @@ namespace ADOKit.Utilities
 
                     }
 
-                    // otherwise PAT was provided
+                    // otherwise PAT/Access Token was provided
                     else
                     {
                         webRequest.Headers.Add("Authorization", "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes(":" + credentials)));
                     }
 
                     // dump webrequest headers for debug 
-                    /* for (int i = 0; i < webRequest.Headers.Count; i++)
+                    /*for (int i = 0; i < webRequest.Headers.Count; i++)
                     {
                         Console.WriteLine("[+] Request header : " + webRequest.Headers.Keys[i].ToString() + " / " + webRequest.Headers[i]);
-                    } */
+                    }*/
 
                     // get web response and status code
                     HttpWebResponse myWebResponse = (HttpWebResponse)await webRequest.GetResponseAsync();

--- a/ADOKit/packages.config
+++ b/ADOKit/packages.config
@@ -2,5 +2,23 @@
 <packages>
   <package id="Costura.Fody" version="3.3.3" targetFramework="net48" />
   <package id="Fody" version="4.0.2" targetFramework="net48" developmentDependency="true" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.Memory" version="9.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.TimeProvider" version="8.0.1" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="8.6.1" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="8.6.1" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Logging" version="8.6.1" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Tokens" version="8.6.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="6.0.2" targetFramework="net48" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="8.6.1" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="8.0.5" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Presentation slides and demos are included in [BHUSA Arsenal 2024](BHUSA_Arsenal
   - Recon
     - [Validate Azure DevOps Access](#validate-azure-devops-access)
     - [Whoami](#whoami)
+	- [List Orgs](#List-orgs)
     - [List Repos](#List-repos)
     - [Search Repos](#Search-repos)
     - [List Projects](#list-projects)
@@ -108,6 +109,7 @@ Take the below steps to setup Visual Studio in order to compile the project your
 * Recon
   * <b>check</b> - Check whether organization uses Azure DevOps and if credentials are valid
   * <b>whoami</b> - List the current user and its group memberships
+  * <b>listorgs</b> - List accessible or all organizations within Azure DevOps
   * <b>listrepo</b> - List all repositories
   * <b>searchrepo</b> - Search for given repository
   * <b>listproject</b> - List all projects
@@ -174,7 +176,7 @@ Below are the authentication options you have with ADOKit when authenticating to
   * `/credential:eyJ0...`
 * **Personal Access Token (PAT)** - This will be an access token/API key that will be a single string.
   * `/credential:apiToken`
-* **Stolen Access Token** - If you can steal or refresh a suitable access token you can also use it. When using an access token, it must be valid for the resource of Azure Resource Manager (ARM) - `"aud":"https://management.core.windows.net/"`
+* **Stolen Access Token** - If you can steal or refresh a suitable access token you can also use it. When using an access token, it must be valid for the resource of Azure Resource Manager (ARM) - `"aud":"https://management.core.windows.net/"` or Azure Devops - `"aud":"499b84ac-1321-427f-aa17-267ca6975798"`
   * `/credential:eyJ0..`
 
 ## Module Details Table
@@ -183,7 +185,8 @@ The below table shows the permissions required for each module.
 Attack Scenario | Module  | Special Permissions? | Notes
 --- |--- | --- | ---
 Recon | `check` |  No | 
-Recon | `whoami` |  No | 
+Recon | `whoami` |  No |
+Recon | `listorgs` |  No | 
 Recon | `listrepo` |  No | 
 Recon | `searchrepo` |  No | 
 Recon | `listproject` |  No | 
@@ -319,6 +322,41 @@ Timestamp:      4/4/2023 11:33:12 AM
            [YourOrganization]\Project Collection Administrators |                  Project Collection Administrators | Members of this application group can perform all privileged operations on the Team Project Collection.
 
 4/4/23 15:33:19 Finished execution of whoami
+
+```
+
+### List Orgs
+
+#### Use Case
+
+> *Retrieve organizations using a given access token. By default, only organizations accessible with the access token are listed. Use `/mode:aad` to list all DevOps organizations within the Azure AD tenant. Optionally, specify a custom AEX endpoint with `/endpoint:ENDPOINT_NAME`. Additional endpoints can be discovered by inspecting the "X-VSS-DeploymentAffinity" cookie from `aex.dev.azure.com`.*
+
+
+#### Syntax
+
+Provide the `listorgs` module, along with any relevant authentication information. This will output the current user and all of its group memberhips.
+
+`ADOKit.exe listorgs /credential:eyj0... [/mode:aad] [/endpoint:ENDPOINT_NAME]`
+
+#### Example Output
+
+```
+C:\>ADOKit.exe listorgs /credential:eyj0..."
+
+==================================================
+Module:         listorgs
+Auth Type:      Azure Access Token
+Target URL:     https://app.vssps.visualstudio.com                                                                                                                                                                                                                                                                                                Timestamp:      3/14/2025 2:26:45 PM
+==================================================                                                                                                                                                 
+
+[*] INFO: Checking credentials provided
+
+[+] SUCCESS: Credentials provided are VALID.
+
+                         Organization ID |                        Organization Name
+-----------------------------------------------------------------------------------
+    390a7474-e2f2-4b98-b538-4a547fa9f5e3 |                             solar-devops
+    b63b999f-43f2-48c5-998d-b31cbf4c2f8e |                             lunar-devops
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Presentation slides and demos are included in [BHUSA Arsenal 2024](BHUSA_Arsenal
   - Recon
     - [Validate Azure DevOps Access](#validate-azure-devops-access)
     - [Whoami](#whoami)
-	- [List Orgs](#List-orgs)
+    - [List Orgs](#List-orgs)
     - [List Repos](#List-repos)
     - [Search Repos](#Search-repos)
     - [List Projects](#list-projects)
@@ -329,12 +329,12 @@ Timestamp:      4/4/2023 11:33:12 AM
 
 #### Use Case
 
-> *Retrieve organizations using a given access token. By default, only organizations accessible with the access token are listed. Use `/mode:aad` to list all DevOps organizations within the Azure AD tenant. Optionally, specify a custom AEX endpoint with `/endpoint:ENDPOINT_NAME`. Additional endpoints can be discovered by inspecting the "X-VSS-DeploymentAffinity" cookie from `aex.dev.azure.com`.*
+> *Retrieve organizations using a given access token.*
 
 
 #### Syntax
 
-Provide the `listorgs` module, along with any relevant authentication information. This will output the current user and all of its group memberhips.
+Provide the `listorgs` module, along with any relevant authentication information. By default, only organizations accessible with the access token are listed. Use `/mode:aad` to list all DevOps organizations within the Azure AD tenant. Optionally, specify a custom AEX endpoint with `/endpoint:ENDPOINT_NAME`. Additional endpoints can be discovered by inspecting the "X-VSS-DeploymentAffinity" cookie from `aex.dev.azure.com`.
 
 `ADOKit.exe listorgs /credential:eyj0... [/mode:aad] [/endpoint:ENDPOINT_NAME]`
 
@@ -346,7 +346,9 @@ C:\>ADOKit.exe listorgs /credential:eyj0..."
 ==================================================
 Module:         listorgs
 Auth Type:      Azure Access Token
-Target URL:     https://app.vssps.visualstudio.com                                                                                                                                                                                                                                                                                                Timestamp:      3/14/2025 2:26:45 PM
+Target URL:     https://app.vssps.visualstudio.com
+
+Timestamp:      3/14/2025 2:26:45 PM
 ==================================================                                                                                                                                                 
 
 [*] INFO: Checking credentials provided

--- a/README.md
+++ b/README.md
@@ -334,14 +334,20 @@ Timestamp:      4/4/2023 11:33:12 AM
 
 #### Syntax
 
-Provide the `listorgs` module, along with any relevant authentication information. By default, only organizations accessible with the access token are listed. Use `/mode:aad` to list all DevOps organizations within the Azure AD tenant. Optionally, specify a custom AEX endpoint with `/endpoint:ENDPOINT_NAME`. Additional endpoints can be discovered by inspecting the "X-VSS-DeploymentAffinity" cookie from `aex.dev.azure.com`.
+Provide the `listorgs` module with the required authentication information. By default, this command lists only the organizations accessible with the provided access token. 
 
-`ADOKit.exe listorgs /credential:eyj0... [/mode:aad] [/endpoint:ENDPOINT_NAME]`
+- Use **`/mode:aad`** to enumerate **all** DevOps organizations within the Azure AD tenant, regardless of direct access.
+- Use **`/endpoint:ENDPOINT_NAME`** to specify a custom AEX endpoint.  
+  - Additional endpoints can be identified by inspecting the `"X-VSS-DeploymentAffinity"` cookie from `aex.dev.azure.com`.
+
+`ADOKit.exe listorgs /credential:"eyj0..." [/mode:aad] [/endpoint:ENDPOINT_NAME]`
+
+`ADOKit.exe listorgs /credential:"eyj0..." /mode:aad /endpoint:aexprodeus21`
 
 #### Example Output
 
 ```
-C:\>ADOKit.exe listorgs /credential:eyj0..."
+C:\>ADOKit.exe listorgs /credential:"eyj0..."
 
 ==================================================
 Module:         listorgs


### PR DESCRIPTION
This PR adds a new recon module, `listorgs`, enabling operators to enumerate Azure DevOps organizations using a valid access token. The module supports two modes:

- **Default Mode:** Lists only the organizations the provided access token has direct access to.
- **AAD Mode (`/mode:aad`)**: Enumerates *all* organizations within the Azure AD tenant.
  - Operators can override the default AEX endpoint by specifying `/endpoint:ENDPOINT_NAME`.
  
  
![image](https://github.com/user-attachments/assets/4072a0f8-958f-46e0-aee9-29518bf710e5)


This module enhances situational awareness when an operator obtains a valid token (e.g., from a beacon or phishing scenario) but lacks visibility into the organizations linked to it.

### Additional Insights

- Azure DevOps tokens can be obtained from various FOCI clients. For example, using **ROADTx**, an access token can be derived from a refresh token as follows:

  `roadtx refreshtokento -c 1950a258-227b-4e31-a9cf-717495945fc2 -r 499b84ac-1321-427f-aa17-267ca6975798/.default`

- The following blog provides further insights into client IDs that can be used to acquire an Azure DevOps access token:  
[DevOps Access Is Closer Than You Assume](https://zolder.io/blog/devops-access-is-closer-than-you-assume/)

